### PR TITLE
changed event creation to be supported in IE

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 # Revision history for re-event
 
+## 1.1.1 -- 2018-07-19
+
+* Change event creation syntax to support IE
+
 ## 1.1.0 -- 2018-05-22
 
 * Remove unnecessary dependency on bs-json

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "re-event",
   "private": true,
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "",
   "main": "index.js",
   "keywords": [],

--- a/src/REvent.re
+++ b/src/REvent.re
@@ -26,6 +26,7 @@ let emit = (event: event) : unit => js_dispatchEvent(document, event);
 /* We return the same listener to easily remove it later using `off` */
 let on = (eventType: string, listener: listener) : listener => {
   js_addEventListener(document, eventType, listener, false);
+  listener
 };
 
 let off = (eventType: string, listener: listener) : unit =>

--- a/src/REvent.re
+++ b/src/REvent.re
@@ -6,9 +6,11 @@ type listener = event => unit;
 
 [@bs.val] external document : dom = "document";
 
-[@bs.new] external js_createEvent : string => event = "Event";
+[@bs.send] external js_createEvent : (dom, string) => event = "createEvent"; 
 
-[@bs.send] external js_addEventListener : (dom, string, listener) => listener = "addEventListener";
+[@bs.send] external js_initEvent : (event, string, bool, bool) => unit = "initEvent";
+
+[@bs.send] external js_addEventListener : (dom, string, listener, bool) => listener = "addEventListener";
 
 [@bs.send] external js_removeEventListener : (dom, string, listener) => unit =
   "removeEventListener";
@@ -23,15 +25,15 @@ let emit = (event: event) : unit => js_dispatchEvent(document, event);
 
 /* We return the same listener to easily remove it later using `off` */
 let on = (eventType: string, listener: listener) : listener => {
-  js_addEventListener(document, eventType, listener);
-  listener
+  js_addEventListener(document, eventType, listener, false);
 };
 
 let off = (eventType: string, listener: listener) : unit =>
   js_removeEventListener(document, eventType, listener);
 
 let createEvent = (eventName: string, payload: option(Js.Json.t)) => {
-  let ev = js_createEvent(eventName);
+  let ev = js_createEvent(document, "Event");
+  js_initEvent(ev, eventName, true, true);
   switch payload {
   | None => ev
   | Some(p) =>


### PR DESCRIPTION
As seen [here](https://developer.mozilla.org/en-US/docs/Web/Guide/Events/Creating_and_triggering_events#Creating_custom_events), creating events in Internet Explorer requires slightly different syntax.

Now the events should work in IE as well.